### PR TITLE
Require OwnedUpgradeabilityProxy contracts to receive an initial implementation on construction time

### DIFF
--- a/contracts/mocks/DummyImplementation.sol
+++ b/contracts/mocks/DummyImplementation.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.4.21;
 
 contract DummyImplementation {
-
+  function get() public view returns (bool) {
+    return true;
+  }
 }

--- a/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
@@ -28,7 +28,7 @@ contract OwnedUpgradeabilityProxy is UpgradeabilityProxy {
   /**
    * @dev the constructor sets the original owner of the contract to the sender account.
    */
-  function OwnedUpgradeabilityProxy() public {
+  function OwnedUpgradeabilityProxy(address _implementation) UpgradeabilityProxy(_implementation) public {
     setUpgradeabilityOwner(msg.sender);
   }
 

--- a/contracts/upgradeability/Proxy.sol
+++ b/contracts/upgradeability/Proxy.sol
@@ -17,7 +17,6 @@ contract Proxy {
    */
   function () payable public {
     address _impl = implementation();
-    require(_impl != address(0));
 
     assembly {
       let ptr := mload(0x40)

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -20,7 +20,9 @@ contract UpgradeabilityProxy is Proxy {
   /**
    * @dev Constructor function
    */
-  function UpgradeabilityProxy() public {}
+  function UpgradeabilityProxy(address _implementation) public {
+    setImplementation(_implementation);
+  }
 
   /**
    * @dev Tells the address of the current implementation

--- a/contracts/upgradeability/UpgradeabilityProxyFactory.sol
+++ b/contracts/upgradeability/UpgradeabilityProxyFactory.sol
@@ -25,8 +25,7 @@ contract UpgradeabilityProxyFactory {
    * @return address of the new proxy created
    */
   function createProxy(address owner, address implementation) public returns (OwnedUpgradeabilityProxy) {
-    OwnedUpgradeabilityProxy proxy = _createProxy();
-    proxy.upgradeTo(implementation);
+    OwnedUpgradeabilityProxy proxy = _createProxy(implementation);
     proxy.transferProxyOwnership(owner);
     return proxy;
   }
@@ -40,8 +39,8 @@ contract UpgradeabilityProxyFactory {
    * @return address of the new proxy created
    */
   function createProxyAndCall(address owner, address implementation, bytes data) public payable returns (OwnedUpgradeabilityProxy) {
-    OwnedUpgradeabilityProxy proxy = _createProxy();
-    proxy.upgradeToAndCall.value(msg.value)(implementation, data);
+    OwnedUpgradeabilityProxy proxy = _createProxy(implementation);
+    require(proxy.call.value(msg.value)(data));
     proxy.transferProxyOwnership(owner);
     return proxy;
   }
@@ -50,8 +49,8 @@ contract UpgradeabilityProxyFactory {
    * @dev Internal function to create an upgradeable proxy
    * @return address of the new proxy created
    */
-  function _createProxy() internal returns (OwnedUpgradeabilityProxy) {
-    OwnedUpgradeabilityProxy proxy = new OwnedUpgradeabilityProxy();
+  function _createProxy(address implementation) internal returns (OwnedUpgradeabilityProxy) {
+    OwnedUpgradeabilityProxy proxy = new OwnedUpgradeabilityProxy(implementation);
     emit ProxyCreated(proxy);
     return proxy;
   }

--- a/test/application/management/PackagedAppManager.test.js
+++ b/test/application/management/PackagedAppManager.test.js
@@ -94,7 +94,7 @@ contract('PackagedAppManager', ([_, managerOwner, packageOwner, directoryOwner, 
           await this.zeroVersionDirectory.setImplementation(contract, this.implementation_v0, { from: directoryOwner })
 
           const { receipt } = await this.manager.create(contract)
-          this.logs = decodeLogs([receipt.logs[0]], UpgradeabilityProxyFactory)
+          this.logs = decodeLogs([receipt.logs[1]], UpgradeabilityProxyFactory)
           this.proxyAddress = this.logs.find(l => l.event === 'ProxyCreated').args.proxy
           this.proxy = await OwnedUpgradeabilityProxy.at(this.proxyAddress)
         })
@@ -130,7 +130,7 @@ contract('PackagedAppManager', ([_, managerOwner, packageOwner, directoryOwner, 
           await this.zeroVersionDirectory.setImplementation(contract, this.behavior.address, { from: directoryOwner })
 
           const { receipt } = await this.manager.createAndCall(contract, initializeData, { value })
-          this.logs = decodeLogs([receipt.logs[0]], UpgradeabilityProxyFactory)
+          this.logs = decodeLogs([receipt.logs[1]], UpgradeabilityProxyFactory)
           this.proxyAddress = this.logs.find(l => l.event === 'ProxyCreated').args.proxy
           this.proxy = await OwnedUpgradeabilityProxy.at(this.proxyAddress)
         })
@@ -174,7 +174,7 @@ contract('PackagedAppManager', ([_, managerOwner, packageOwner, directoryOwner, 
       beforeEach(async function () {
         await this.zeroVersionDirectory.setImplementation(contract, this.implementation_v0, { from: directoryOwner })
         const { receipt } = await this.manager.create(contract)
-        this.logs = decodeLogs([receipt.logs[0]], UpgradeabilityProxyFactory)
+        this.logs = decodeLogs([receipt.logs[1]], UpgradeabilityProxyFactory)
         this.proxyAddress = this.logs.find(l => l.event === 'ProxyCreated').args.proxy
         this.proxy = await OwnedUpgradeabilityProxy.at(this.proxyAddress)
         
@@ -222,7 +222,7 @@ contract('PackagedAppManager', ([_, managerOwner, packageOwner, directoryOwner, 
       beforeEach(async function () {
         await this.zeroVersionDirectory.setImplementation(contract, this.implementation_v0, { from: directoryOwner })
         const { receipt } = await this.manager.create(contract)
-        this.logs = decodeLogs([receipt.logs[0]], UpgradeabilityProxyFactory)
+        this.logs = decodeLogs([receipt.logs[1]], UpgradeabilityProxyFactory)
         this.proxyAddress = this.logs.find(l => l.event === 'ProxyCreated').args.proxy
         this.proxy = await OwnedUpgradeabilityProxy.at(this.proxyAddress)
         this.behavior = await InitializableMock.new()

--- a/test/application/management/UnversionedAppManager.test.js
+++ b/test/application/management/UnversionedAppManager.test.js
@@ -50,7 +50,7 @@ contract('UnversionedAppManager', ([_, managerOwner, directoryOwner, anotherAcco
         await this.directory.setImplementation(contract, this.implementation_v0, { from: directoryOwner })
 
         const { receipt } = await this.manager.create(contract)
-        this.logs = decodeLogs([receipt.logs[0]], UpgradeabilityProxyFactory)
+        this.logs = decodeLogs([receipt.logs[1]], UpgradeabilityProxyFactory)
         this.proxyAddress = this.logs.find(l => l.event === 'ProxyCreated').args.proxy
         this.proxy = await OwnedUpgradeabilityProxy.at(this.proxyAddress)
       })
@@ -86,7 +86,7 @@ contract('UnversionedAppManager', ([_, managerOwner, directoryOwner, anotherAcco
         await this.directory.setImplementation(contract, this.behavior.address, { from: directoryOwner })
 
         const { receipt } = await this.manager.createAndCall(contract, initializeData, { value })
-        this.logs = decodeLogs([receipt.logs[0]], UpgradeabilityProxyFactory)
+        this.logs = decodeLogs([receipt.logs[1]], UpgradeabilityProxyFactory)
         this.proxyAddress = this.logs.find(l => l.event === 'ProxyCreated').args.proxy
         this.proxy = await OwnedUpgradeabilityProxy.at(this.proxyAddress)
       })
@@ -130,7 +130,7 @@ contract('UnversionedAppManager', ([_, managerOwner, directoryOwner, anotherAcco
     beforeEach(async function () {
       await this.directory.setImplementation(contract, this.implementation_v0, { from: directoryOwner })
       const { receipt } = await this.manager.create(contract)
-      this.logs = decodeLogs([receipt.logs[0]], UpgradeabilityProxyFactory)
+      this.logs = decodeLogs([receipt.logs[1]], UpgradeabilityProxyFactory)
       this.proxyAddress = this.logs.find(l => l.event === 'ProxyCreated').args.proxy
       this.proxy = await OwnedUpgradeabilityProxy.at(this.proxyAddress)
     })
@@ -174,7 +174,7 @@ contract('UnversionedAppManager', ([_, managerOwner, directoryOwner, anotherAcco
     beforeEach(async function () {
       await this.directory.setImplementation(contract, this.implementation_v0, { from: directoryOwner })
       const { receipt } = await this.manager.create(contract)
-      this.logs = decodeLogs([receipt.logs[0]], UpgradeabilityProxyFactory)
+      this.logs = decodeLogs([receipt.logs[1]], UpgradeabilityProxyFactory)
       this.proxyAddress = this.logs.find(l => l.event === 'ProxyCreated').args.proxy
       this.proxy = await OwnedUpgradeabilityProxy.at(this.proxyAddress)
       this.behavior = await InitializableMock.new()

--- a/test/migrations/Migratable.test.js
+++ b/test/migrations/Migratable.test.js
@@ -15,11 +15,14 @@ const SampleChildV4 = artifacts.require('SampleChildV4');
 const SampleChildV5 = artifacts.require('SampleChildV5');
 const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy');
 
+const DummyImplementation = artifacts.require('DummyImplementation');
+
 contract('Migratable', function ([_, owner, registrar]) {
   const from = owner;
-  let v1, v2, v3, v4, v5;
+  let v0, v1, v2, v3, v4, v5;
 
   before(async function () {
+    v0 = await DummyImplementation.new({ from: registrar });
     v1 = await SampleChildV1.new({ from: registrar });
     v2 = await SampleChildV2.new({ from: registrar });
     v3 = await SampleChildV3.new({ from: registrar });
@@ -28,7 +31,7 @@ contract('Migratable', function ([_, owner, registrar]) {
   });
 
   beforeEach(async function () {
-    this.proxy = await OwnedUpgradeabilityProxy.new({ from });
+    this.proxy = await OwnedUpgradeabilityProxy.new(v0.address, { from });
     this.contract = SampleChildV1.at(this.proxy.address);
   });
 

--- a/test/upgradeability/OwnedUpgradeabilityProxy.test.js
+++ b/test/upgradeability/OwnedUpgradeabilityProxy.test.js
@@ -17,18 +17,8 @@ contract('OwnedUpgradeabilityProxy', ([_, owner, anotherAccount]) => {
   })
 
   beforeEach(async function () {
-    this.factory = await UpgradeabilityProxyFactory.new()
-    const { logs } = await this.factory.createProxy(owner, this.implementation_v0)
-    this.proxyAddress = logs.find(l => l.event === 'ProxyCreated').args.proxy
-    this.proxy = await OwnedUpgradeabilityProxy.at(this.proxyAddress)
-  })
-
-  describe('owner', function () {
-    it('transfers the ownership to the requested owner', async function () {
-      const proxyOwner = await this.proxy.proxyOwner()
-
-      assert.equal(proxyOwner, owner)
-    })
+    this.proxy = await OwnedUpgradeabilityProxy.new(this.implementation_v0, { from: owner })
+    this.proxyAddress = this.proxy.address;
   })
 
   describe('implementation', function () {
@@ -37,30 +27,12 @@ contract('OwnedUpgradeabilityProxy', ([_, owner, anotherAccount]) => {
 
       assert.equal(implementation, this.implementation_v0)
     })
-  })
 
-  describe('fallback', function () {
-    beforeEach(async function () {
-      this.behavior = await InitializableMock.new()
-      this.proxy = await OwnedUpgradeabilityProxy.new()
-      this.mock = InitializableMock.at(this.proxy.address)
-    })
+    it('delegates to the implementation', async function () {
+      const dummy = new DummyImplementation(this.proxyAddress);
+      const value = await dummy.get();
 
-    describe('when there is an implementation set', function () {
-      it('calls the implementation', async function () {
-        await this.proxy.upgradeTo(this.behavior.address)
-
-        await this.mock.initialize(42)
-        const value = await this.mock.x()
-
-        assert.equal(value, 42)
-      })
-    })
-
-    describe.skip('when there is no implementation set', function () {
-      it('reverts', async function () {
-        await assertRevert(this.mock.initialize(42))
-      })
+      assert.equal(value, true)
     })
   })
 

--- a/test/upgradeability/OwnedUpgradeabilityProxy.test.js
+++ b/test/upgradeability/OwnedUpgradeabilityProxy.test.js
@@ -57,7 +57,7 @@ contract('OwnedUpgradeabilityProxy', ([_, owner, anotherAccount]) => {
       })
     })
 
-    describe('when there is no implementation set', function () {
+    describe.skip('when there is no implementation set', function () {
       it('reverts', async function () {
         await assertRevert(this.mock.initialize(42))
       })


### PR DESCRIPTION
This PR removes the line in the fallback function that verifies if a proxy's implementation is non-zero.

Since this was in the fallback function it was wasting gas on each call to the proxy. I think this check (or actually the one introduced in #53) should be performed by `UpgradeabilityProxy` when the implementation is set, and not in the fallback function. However, an `UpgradeabilityProxy` instance is created without an initial implementation, and this results in an intermediate state where the condition that the implementation has code isn't valid.

I don't think an `UpgradeabilityProxy` should be constructed without a valid implementation. I'd propose to change its constructor to take an initial implementation address. This affects the factory implementation because instead of deploying the proxy and then doing upgradeToAndCall, it will have to deploy it with its implementation set, and then call the function manually. I don't see a downside to this.