### PR TITLE
Fix decodeLogs when logs include events from other contracts

### DIFF
--- a/lib/decodeLogs.js
+++ b/lib/decodeLogs.js
@@ -1,10 +1,17 @@
 const SolidityEvent = require('web3/lib/web3/event.js');
 
 function decodeLogs (logs, contract) {
-  return logs.map(log => {
-    const event = new SolidityEvent(null, contract.events[log.topics[0]], '0x0');
-    return event.decode(log);
-  });
+  const decodedLogs = [];
+  
+  for (const log of logs) {
+    const eventName = log.topics[0];
+    if (eventName in contract.events) {
+      const eventType = new SolidityEvent(null, contract.events[eventName], '0x0');
+      decodedLogs.push(eventType.decode(log));
+    }
+  }
+        
+  return decodedLogs;
 }
 
 module.exports = decodeLogs


### PR DESCRIPTION
I think this fixes #72.

The problem was that a transaction can include events from other contracts, thus sometimes `contract.events[log.topics[0]]` was evaluating to `undefined`.