### PR TITLE
Ability to run the complex example in development networks

### DIFF
--- a/examples/complex/package.json
+++ b/examples/complex/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "compile": "rm -rf build && npx truffle compile",
-    "start": "npm run compile && npx truffle exec index.js --network ropsten",
+    "start": "npm run deploy",
+    "deploy": "npm run compile && npx truffle exec index.js --network development",
+    "deploy_ropsten": "npm run compile && npx truffle exec index.js --network ropsten",
     "test": "npm run compile && npx truffle test"
   },
   "keywords": [


### PR DESCRIPTION
Based on PR #91 (merge that first)
Fixes #65

Small PR that makes use of the deploy script's `getStdLib` used for testing to be able to run the script in development.