### PR TITLE
Run examples tests directly from root package.json (instead of travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
     - env: SOLIDITY_COVERAGE=true
 script:
   - npm test
-  - npm run prepack && cd examples/complex && npm i && npm test
 notifications:
   slack:
     rooms:

--- a/examples/complex/package-lock.json
+++ b/examples/complex/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "upgradeability-lib-complex-example",
+  "name": "zos-lib-complex-example",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "zeppelin_os library",
   "scripts": {
     "prepack": "truffle compile && babel src --out-dir lib",
-    "test_examples": "cd examples/complex && npm i && npm test",
-    "test": "scripts/test.sh && npm run test_examples"
+    "test_examples": "npm run prepack && cd examples/complex && npm i && npm test",
+    "test_root": "scripts/test.sh",
+    "test": "npm run test_root && npm run test_examples"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "zeppelin_os library",
   "scripts": {
     "prepack": "truffle compile && babel src --out-dir lib",
-    "test": "scripts/test.sh"
+    "test_examples": "cd examples/complex && npm i && npm test",
+    "test": "scripts/test.sh && npm run test_examples"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previously, the example's tests were ran by travis builds. this caused confusion with npm tests in root passing, but not passing in CI. This PR makes it more clear that example tests are ran together with the root tests.