### PR TITLE
Fix web3 is not defined error in CLI

### DIFF
--- a/src/utils/Contracts.js
+++ b/src/utils/Contracts.js
@@ -4,8 +4,7 @@ import truffleProvision from 'truffle-provisioner'
 
 const DEFAULT_TESTING_TX_PARAMS = {
   gas: 6721975,
-  gasPrice: 100000000000,
-  from: web3.eth.accounts[0]
+  gasPrice: 100000000000
 }
 
 export default {
@@ -39,7 +38,7 @@ export default {
 
   _provideContractForTesting(contract) {
     contract.setProvider(web3.currentProvider)
-    contract.defaults(DEFAULT_TESTING_TX_PARAMS)
+    contract.defaults({ from: web3.eth.accounts[0], ... DEFAULT_TESTING_TX_PARAMS })
     return contract
   },
 


### PR DESCRIPTION
When CLI imported lib files, it imported the Contracts module which
required web3 to be defined at top level. This fails if it is not
being run in the context of truffle.