### PR TITLE
Silences logger by default

### DIFF
--- a/src/utils/Logger.js
+++ b/src/utils/Logger.js
@@ -1,8 +1,22 @@
 import colors from 'colors'
 
+const defaults = {
+  verbose: false,
+  silent: true
+};
+
 export default class Logger {
-  constructor(prefix) {
+  static silent(value) {
+    defaults.silent = value;
+  }
+
+  static verbose(value) {
+    defaults.verbose = value;
+  }
+
+  constructor(prefix, opts) {
     this.prefix = prefix
+    this.opts = Object.assign({}, defaults, opts);
   }
 
   out(msg) {
@@ -10,10 +24,21 @@ export default class Logger {
   }
 
   info(msg) {
-    console.error(`[${this.prefix}] ${msg}`.green)
+    this.log(msg, 'green')
   }
 
   error(msg) {
-    console.error(`[${this.prefix}] ${msg}`.red)
+    this.log(msg, 'red')
+  }
+
+  log(msg, color) {
+    if (this.opts.silent) {
+      return;
+    }
+    if (this.opts.verbose) {
+      console.error(`[${this.prefix}] ${msg}`[color])
+    } else {
+      console.error(msg[color])
+    }
   }
 }

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,10 +1,1 @@
 'use strict';
-
-import Logger from '../src/utils/Logger'
-
-function muteLogging() {
-  Logger.prototype.info = msg => {}
-  Logger.prototype.error = msg => {}
-}
-
-muteLogging()


### PR DESCRIPTION
Logger is now silent by default, and must be activated (either
globally or per instance) in order to actually log. Added verbose
flag to control whether to output prefixes or not.

Closes #122 