### PR TITLE
Reload defaults in logger

### DIFF
--- a/src/utils/Logger.js
+++ b/src/utils/Logger.js
@@ -15,12 +15,8 @@ export default class Logger {
   }
 
   constructor(prefix, opts) {
-    this.prefix = prefix
-    this.opts = Object.assign({}, defaults, opts);
-  }
-
-  out(msg) {
-    console.log(msg)
+    this.prefix = prefix;
+    this._opts = opts;
   }
 
   info(msg) {
@@ -40,5 +36,9 @@ export default class Logger {
     } else {
       console.error(msg[color])
     }
+  }
+
+  get opts() {
+    return Object.assign({}, this._opts, defaults)
   }
 }


### PR DESCRIPTION
Do not load defaults only on creation, so defaults can be modified
after the logger was set up.