### PR TITLE
Default proxy contract name to contract class name in App

### DIFF
--- a/contracts/mocks/DummyImplementation.sol
+++ b/contracts/mocks/DummyImplementation.sol
@@ -1,5 +1,9 @@
 pragma solidity ^0.4.21;
 
+contract Impl {
+  function version() public pure returns (string); 
+}
+
 contract DummyImplementation {
   uint256 public value;
 

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -83,6 +83,7 @@ export default class App {
   }
 
   async createProxy(contractClass, contractName, initMethodName, initArgs) {
+    if (!contractName) contractName = contractClass.contractName;
     const { receipt } = typeof(initArgs) === 'undefined'
       ? await this._createProxy(contractName)
       : await this._createProxyAndCall(contractClass, contractName, initMethodName, initArgs)
@@ -96,6 +97,7 @@ export default class App {
   }
 
   async upgradeProxy(proxyAddress, contractClass, contractName, initMethodName, initArgs) {
+    if (!contractName) contractName = contractClass.contractName;
     const { receipt } = typeof(initArgs) === 'undefined'
       ? await this._upgradeProxy(proxyAddress, contractName)
       : await this._upgradeProxyAndCall(proxyAddress, contractClass, contractName, initMethodName, initArgs)

--- a/test/src/app/App.test.js
+++ b/test/src/app/App.test.js
@@ -4,6 +4,7 @@ require('../../setup')
 import App from '../../../src/app/App';
 
 const AppDirectory = artifacts.require('AppDirectory');
+const Impl = artifacts.require('Impl');
 const ImplV1 = artifacts.require('DummyImplementation');
 const ImplV2 = artifacts.require('DummyImplementationV2');
 
@@ -135,6 +136,13 @@ contract('App', function ([_, owner]) {
           (await this.proxy.value()).toNumber().should.eq(10);
         });
       });
+
+      describe('with implicit contract name', async function () {
+        beforeEach('creating a proxy', async function () {
+          this.proxy = await this.app.createProxy(Impl);
+        });
+        shouldReturnProxy();
+      });
     });
     
     describe('upgradeProxy', function () {
@@ -170,6 +178,14 @@ contract('App', function ([_, owner]) {
         it('should run migration', async function () {
           (await this.proxy.value()).toNumber().should.eq(20);
         });
+      });
+
+      describe('with implicit contract name', async function () {
+        beforeEach('upgrading the proxy', async function () {
+          await this.app.upgradeProxy(this.proxy.address, Impl);
+        });
+
+        shouldUpgradeProxy();
       });
     });
 


### PR DESCRIPTION
Allows to call createProxy and upgradeProxy in App without
specifying the name of the contract name, and retrieving it from
the class. Particularly useful when using the App object for testing.