### PR TITLE
Remove incorrect logs from package provider

### DIFF
--- a/src/package/PackageProvider.js
+++ b/src/package/PackageProvider.js
@@ -12,10 +12,8 @@ const PackageProvider = {
   },
 
   _fetchPackage(address) {
-    log.info('Deploying new Package...')
     const Package = Contracts.getFromLib('Package')
     this.package = new Package(address)
-    log.info(`Deployed Package ${this.package.address}`)
   }
 }
 


### PR DESCRIPTION
Do not log `Deploying new package` when fetching package. Required for https://github.com/zeppelinos/zos-cli/issues/191.