### PR TITLE
Use zos-lib contracts instead of truffle artifacts for testing

### DIFF
--- a/examples/complex/contracts/Imports.sol
+++ b/examples/complex/contracts/Imports.sol
@@ -1,9 +1,0 @@
-pragma solidity ^0.4.21;
-
-import "zos-lib/contracts/application/AppDirectory.sol";
-import "zos-lib/contracts/application/PackagedApp.sol";
-import "zos-lib/contracts/application/UnversionedApp.sol";
-import "zos-lib/contracts/application/versioning/Package.sol";
-import "zos-lib/contracts/application/versioning/ImplementationDirectory.sol";
-import "zos-lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol";
-import "zos-lib/contracts/upgradeability/UpgradeabilityProxyFactory.sol";

--- a/examples/complex/index.js
+++ b/examples/complex/index.js
@@ -5,10 +5,11 @@ global.artifacts = artifacts;
 const args = require('minimist')(process.argv.slice(2));
 const network = args.network;
 
-const ImplementationDirectory = artifacts.require('ImplementationDirectory');
-const MintableERC721Token = artifacts.require('MintableERC721Token');
 const { Logger, App, Contracts } = require('zos-lib')
 const log = new Logger('ComplexExample')
+
+const MintableERC721Token = Contracts.getFromLocal('MintableERC721Token');
+const ImplementationDirectory = Contracts.getFromNodeModules('zos-lib', 'ImplementationDirectory');
 
 const owner = web3.eth.accounts[1];
 const contractName = 'Donations';

--- a/examples/complex/test/App.test.js
+++ b/examples/complex/test/App.test.js
@@ -1,11 +1,12 @@
 'use strict';
 
-const DonationsV2 = artifacts.require('DonationsV2');
-
+const { Contracts } = require('zos-lib')
 const deploy = require('../index.js');
 const validateAddress = require('./helpers/validateAddress.js');
 const shouldBehaveLikeDonations = require('./Donations.behavior.js');
 const shouldBehaveLikeDonationsWithTokens = require('./DonationsWithTokens.behavior.js');
+
+const DonationsV2 = Contracts.getFromLocal('DonationsV2');
 require('chai').should()
 
 contract('App', ([_, owner, donor, wallet]) => {

--- a/examples/complex/test/DonationsV1.test.js
+++ b/examples/complex/test/DonationsV1.test.js
@@ -1,5 +1,7 @@
-const DonationsV1 = artifacts.require('DonationsV1');
+const { Contracts } = require('zos-lib')
 const shouldBehaveLikeDonations = require('./Donations.behavior.js');
+
+const DonationsV1 = Contracts.getFromLocal('DonationsV1');
 
 contract('DonationsV1', ([_, owner, donor, wallet]) => {
 

--- a/examples/complex/test/DonationsV2.test.js
+++ b/examples/complex/test/DonationsV2.test.js
@@ -1,7 +1,8 @@
-const DonationsV2 = artifacts.require('DonationsV2');
-const MintableERC721Token = artifacts.require('MintableERC721Token');
-
+const { Contracts } = require('zos-lib')
 const shouldBehaveLikeDonationsWithTokens = require('./DonationsWithTokens.behavior.js');
+
+const DonationsV2 = Contracts.getFromLocal('DonationsV2');
+const MintableERC721Token = Contracts.getFromLocal('MintableERC721Token');
 
 contract('DonationsV2', ([_, owner, donor, wallet]) => {
 

--- a/examples/simple/contracts/Imports.sol
+++ b/examples/simple/contracts/Imports.sol
@@ -1,3 +1,0 @@
-pragma solidity ^0.4.21;
-
-import "zos-lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol";

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const MyContract_v0 = artifacts.require('MyContract_v0');
-const MyContract_v1 = artifacts.require('MyContract_v1');
-const AdminUpgradeabilityProxy = artifacts.require('zos-lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol');
-
+const { Contracts } = require('zos-lib')
+const MyContract_v0 = Contracts.getFromLocal('MyContract_v0');
+const MyContract_v1 = Contracts.getFromLocal('MyContract_v1');
+const AdminUpgradeabilityProxy = Contracts.getFromNodeModules('zos-lib', 'AdminUpgradeabilityProxy');
 
 module.exports = async function() {
-
   console.log('Deploying MyContract v0...');
   const myContract_v0 = await MyContract_v0.new();
 
@@ -17,9 +16,7 @@ module.exports = async function() {
   let myContract = await MyContract_v0.at(proxy.address);
   const x0 = 42;
   await myContract.initialize(x0);
-
 	console.log('Proxy\'s storage value for x: ' + (await myContract.x()).toString());
-
 
   console.log('Deploying MyContract v1...');
   const myContract_v1 = await MyContract_v1.new();
@@ -31,5 +28,4 @@ module.exports = async function() {
   console.log('Proxy\'s storage value for x: ' + (await myContract.x()).toString());
   console.log('Proxy\'s storage value for y: ' + (await myContract.y()).toString());
   console.log('Wohoo! We\'ve upgraded our contract\'s behavior while preserving storage.');
-
 };

--- a/test/contracts/application/AppDirectory.test.js
+++ b/test/contracts/application/AppDirectory.test.js
@@ -1,12 +1,13 @@
 'use strict';
 require('../../setup')
 
+import Contracts from '../../../src/utils/Contracts'
 import assertRevert from '../../../src/test/helpers/assertRevert'
 import shouldBehaveLikeImplementationDirectory from '../../../src/test/behaviors/ImplementationDirectory'
 
-const AppDirectory = artifacts.require('AppDirectory')
-const ImplementationDirectory = artifacts.require('ImplementationDirectory')
-const DummyImplementation = artifacts.require('DummyImplementation')
+const AppDirectory = Contracts.getFromLocal('AppDirectory')
+const ImplementationDirectory = Contracts.getFromLocal('ImplementationDirectory')
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation')
 
 contract('AppDirectory', ([_, owner, stdlibOwner, anotherAddress]) => {
   before(async function () {

--- a/test/contracts/application/PackagedApp.test.js
+++ b/test/contracts/application/PackagedApp.test.js
@@ -1,18 +1,19 @@
 'use strict';
 require('../../setup')
 
+import Contracts from '../../../src/utils/Contracts'
 import encodeCall from '../../../src/helpers/encodeCall'
 import decodeLogs from '../../../src/helpers/decodeLogs'
 import assertRevert from '../../../src/test/helpers/assertRevert'
 import shouldBehaveLikeOwnable from '../../../src/test/behaviors/Ownable'
 
-const Package = artifacts.require('Package')
-const ImplementationDirectory = artifacts.require('ImplementationDirectory')
-const MigratableMock = artifacts.require('MigratableMock')
-const PackagedApp = artifacts.require('PackagedApp')
-const DummyImplementation = artifacts.require('DummyImplementation')
-const AdminUpgradeabilityProxy = artifacts.require('AdminUpgradeabilityProxy')
-const UpgradeabilityProxyFactory = artifacts.require('UpgradeabilityProxyFactory')
+const Package = Contracts.getFromLocal('Package')
+const ImplementationDirectory = Contracts.getFromLocal('ImplementationDirectory')
+const MigratableMock = Contracts.getFromLocal('MigratableMock')
+const PackagedApp = Contracts.getFromLocal('PackagedApp')
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation')
+const AdminUpgradeabilityProxy = Contracts.getFromLocal('AdminUpgradeabilityProxy')
+const UpgradeabilityProxyFactory = Contracts.getFromLocal('UpgradeabilityProxyFactory')
 
 contract('PackagedApp', ([_, appOwner, packageOwner, directoryOwner, anotherAccount]) => {
   const contract = 'ERC721'

--- a/test/contracts/application/UnversionedApp.test.js
+++ b/test/contracts/application/UnversionedApp.test.js
@@ -1,16 +1,17 @@
 'use strict';
 require('../../setup')
 
+import Contracts from '../../../src/utils/Contracts'
 import decodeLogs from '../../../src/helpers/decodeLogs'
 import encodeCall from '../../../src/helpers/encodeCall'
 import assertRevert from '../../../src/test/helpers/assertRevert'
 import shouldBehaveLikeOwnable from '../../../src/test/behaviors/Ownable'
 
-const MigratableMock = artifacts.require('MigratableMock')
-const ImplementationDirectory = artifacts.require('ImplementationDirectory')
-const DummyImplementation = artifacts.require('DummyImplementation')
-const UnversionedApp = artifacts.require('UnversionedApp')
-const UpgradeabilityProxyFactory = artifacts.require('UpgradeabilityProxyFactory')
+const MigratableMock = Contracts.getFromLocal('MigratableMock')
+const ImplementationDirectory = Contracts.getFromLocal('ImplementationDirectory')
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation')
+const UnversionedApp = Contracts.getFromLocal('UnversionedApp')
+const UpgradeabilityProxyFactory = Contracts.getFromLocal('UpgradeabilityProxyFactory')
 
 contract('UnversionedApp', ([_, appOwner, directoryOwner, anotherAccount]) => {
   const contract = 'ERC721'

--- a/test/contracts/application/versioning/FreezableImplementationDirectory.test.js
+++ b/test/contracts/application/versioning/FreezableImplementationDirectory.test.js
@@ -1,11 +1,12 @@
 'use strict';
 require('../../../setup')
 
+import Contracts from '../../../../src/utils/Contracts'
 import assertRevert from '../../../../src/test/helpers/assertRevert'
 import shouldBehaveLikeImplementationDirectory from '../../../../src/test/behaviors/ImplementationDirectory'
 
-const DummyImplementation = artifacts.require('DummyImplementation')
-const FreezableImplementationDirectory = artifacts.require('FreezableImplementationDirectory')
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation')
+const FreezableImplementationDirectory = Contracts.getFromLocal('FreezableImplementationDirectory')
 
 contract('FreezableImplementationDirectory', ([_, owner, anotherAddress]) => {
   before(async function () {

--- a/test/contracts/application/versioning/ImplementationDirectory.test.js
+++ b/test/contracts/application/versioning/ImplementationDirectory.test.js
@@ -1,10 +1,11 @@
 'use strict';
 require('../../../setup')
 
+import Contracts from '../../../../src/utils/Contracts'
 import shouldBehaveLikeImplementationDirectory from '../../../../src/test/behaviors/ImplementationDirectory'
 
-const ImplementationDirectory = artifacts.require('ImplementationDirectory')
-const DummyImplementation = artifacts.require('DummyImplementation')
+const ImplementationDirectory = Contracts.getFromLocal('ImplementationDirectory')
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation')
 
 contract('ImplementationDirectory', function([_, owner, anotherAddress]) {
   beforeEach(async function () {

--- a/test/contracts/application/versioning/Package.test.js
+++ b/test/contracts/application/versioning/Package.test.js
@@ -1,12 +1,13 @@
 'use strict';
 require('../../../setup')
 
+import Contracts from '../../../../src/utils/Contracts'
 import assertRevert from '../../../../src/test/helpers/assertRevert'
 import shouldBehaveLikeOwnable from '../../../../src/test/behaviors/Ownable'
 
-const Package = artifacts.require('Package')
-const ImplementationDirectory = artifacts.require('ImplementationDirectory')
-const DummyImplementation = artifacts.require('DummyImplementation')
+const Package = Contracts.getFromLocal('Package')
+const ImplementationDirectory = Contracts.getFromLocal('ImplementationDirectory')
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation')
 
 contract('Package', ([_, owner, anotherAddress]) => {
   before(async function () {

--- a/test/contracts/application/versioning/Release.test.js
+++ b/test/contracts/application/versioning/Release.test.js
@@ -1,11 +1,12 @@
 'use strict';
 require('../../../setup')
 
+import Contracts from '../../../../src/utils/Contracts'
 import assertRevert from '../../../../src/test/helpers/assertRevert'
 import shouldBehaveLikeImplementationDirectory from '../../../../src/test/behaviors/ImplementationDirectory'
 
-const DummyImplementation = artifacts.require('DummyImplementation');
-const Release = artifacts.require('Release');
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation');
+const Release = Contracts.getFromLocal('Release');
 
 contract('Release', ([_, developer, anotherAddress]) => {
 

--- a/test/contracts/migrations/Initializable.test.js
+++ b/test/contracts/migrations/Initializable.test.js
@@ -1,9 +1,10 @@
 'use strict';
 require('../../setup')
 
+import Contracts from '../../../src/utils/Contracts'
 import assertRevert from '../../../src/test/helpers/assertRevert';
 
-const InitializableMock = artifacts.require('InitializableMock');
+const InitializableMock = Contracts.getFromLocal('InitializableMock');
 
 contract('Initializable', function () {
   beforeEach(async function () {

--- a/test/contracts/migrations/Migratable.test.js
+++ b/test/contracts/migrations/Migratable.test.js
@@ -1,18 +1,19 @@
 'use strict';
 require('../../setup')
 
+import Contracts from '../../../src/utils/Contracts'
 import encodeCall from '../../../src/helpers/encodeCall'
 import decodeLogs from '../../../src/helpers/decodeLogs'
 import assertRevert from '../../../src/test/helpers/assertRevert'
 
-const Migratable = artifacts.require('Migratable');
-const SampleChildV1 = artifacts.require('SampleChildV1');
-const SampleChildV2 = artifacts.require('SampleChildV2');
-const SampleChildV3 = artifacts.require('SampleChildV3');
-const SampleChildV4 = artifacts.require('SampleChildV4');
-const SampleChildV5 = artifacts.require('SampleChildV5');
-const DummyImplementation = artifacts.require('DummyImplementation');
-const AdminUpgradeabilityProxy = artifacts.require('AdminUpgradeabilityProxy');
+const Migratable = Contracts.getFromLocal('Migratable');
+const SampleChildV1 = Contracts.getFromLocal('SampleChildV1');
+const SampleChildV2 = Contracts.getFromLocal('SampleChildV2');
+const SampleChildV3 = Contracts.getFromLocal('SampleChildV3');
+const SampleChildV4 = Contracts.getFromLocal('SampleChildV4');
+const SampleChildV5 = Contracts.getFromLocal('SampleChildV5');
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation');
+const AdminUpgradeabilityProxy = Contracts.getFromLocal('AdminUpgradeabilityProxy');
 
 contract('Migratable', function ([_, owner, registrar]) {
   const from = owner;

--- a/test/contracts/upgradeability/AdminUpgradeabilityProxy.test.js
+++ b/test/contracts/upgradeability/AdminUpgradeabilityProxy.test.js
@@ -1,16 +1,17 @@
 'use strict';
 require('../../setup')
 
+import Contracts from '../../../src/utils/Contracts'
 import encodeCall from '../../../src/helpers/encodeCall'
 import assertRevert from '../../../src/test/helpers/assertRevert'
 
-const MigratableMockV1 = artifacts.require('MigratableMockV1')
-const MigratableMockV2 = artifacts.require('MigratableMockV2')
-const MigratableMockV3 = artifacts.require('MigratableMockV3')
-const MigratableMock = artifacts.require('MigratableMock')
-const DummyImplementation = artifacts.require('DummyImplementation')
-const ClashingImplementation = artifacts.require('ClashingImplementation')
-const AdminUpgradeabilityProxy = artifacts.require('AdminUpgradeabilityProxy')
+const MigratableMockV1 = Contracts.getFromLocal('MigratableMockV1')
+const MigratableMockV2 = Contracts.getFromLocal('MigratableMockV2')
+const MigratableMockV3 = Contracts.getFromLocal('MigratableMockV3')
+const MigratableMock = Contracts.getFromLocal('MigratableMock')
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation')
+const ClashingImplementation = Contracts.getFromLocal('ClashingImplementation')
+const AdminUpgradeabilityProxy = Contracts.getFromLocal('AdminUpgradeabilityProxy')
 
 contract('AdminUpgradeabilityProxy', ([_, admin, anotherAccount]) => {
   before(async function () {

--- a/test/contracts/upgradeability/UpgradeabilityProxyFactory.test.js
+++ b/test/contracts/upgradeability/UpgradeabilityProxyFactory.test.js
@@ -1,13 +1,14 @@
 'use strict';
 require('../../setup')
 
+import Contracts from '../../../src/utils/Contracts'
 import encodeCall from '../../../src/helpers/encodeCall'
 import assertRevert from '../../../src/test/helpers/assertRevert'
 
-const MigratableMock = artifacts.require('MigratableMock')
-const AdminUpgradeabilityProxy = artifacts.require('AdminUpgradeabilityProxy')
-const UpgradeabilityProxyFactory = artifacts.require('UpgradeabilityProxyFactory')
-const DummyImplementation = artifacts.require('DummyImplementation')
+const MigratableMock = Contracts.getFromLocal('MigratableMock')
+const AdminUpgradeabilityProxy = Contracts.getFromLocal('AdminUpgradeabilityProxy')
+const UpgradeabilityProxyFactory = Contracts.getFromLocal('UpgradeabilityProxyFactory')
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation')
 
 contract('UpgradeabilityProxyFactory', ([_, owner]) => {
   before(async function () {

--- a/test/src/app/App.test.js
+++ b/test/src/app/App.test.js
@@ -2,11 +2,12 @@
 require('../../setup')
 
 import App from '../../../src/app/App';
+import Contracts from '../../../src/utils/Contracts'
 
-const AppDirectory = artifacts.require('AppDirectory');
-const Impl = artifacts.require('Impl');
-const ImplV1 = artifacts.require('DummyImplementation');
-const ImplV2 = artifacts.require('DummyImplementationV2');
+const AppDirectory = Contracts.getFromLocal('AppDirectory');
+const Impl = Contracts.getFromLocal('Impl');
+const ImplV1 = Contracts.getFromLocal('DummyImplementation');
+const ImplV2 = Contracts.getFromLocal('DummyImplementationV2');
 
 contract('App', function ([_, owner]) {
   const txParams = { from: owner }

--- a/test/src/package/Package.test.js
+++ b/test/src/package/Package.test.js
@@ -1,10 +1,11 @@
 'use strict'
 require('../../setup')
 
-import assertRevert from '../../../src/test/helpers/assertRevert';
 import Package from '../../../src/package/Package';
+import Contracts from '../../../src/utils/Contracts'
+import assertRevert from '../../../src/test/helpers/assertRevert';
 
-const DummyImplementation = artifacts.require('DummyImplementation')
+const DummyImplementation = Contracts.getFromLocal('DummyImplementation')
 
 contract('Package', function ([_, owner]) {
   const txParams = { from: owner }


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos-cli/issues/209

We don't need to use truffle artifacts for testing, we can use our `Contracts` objects
After this, we don't need to have the `Imports` contract anymore