### PR TITLE
Make FileSystem `copy` function synchronous

### DIFF
--- a/src/utils/FileSystem.js
+++ b/src/utils/FileSystem.js
@@ -51,7 +51,7 @@ export function write(filename, data) {
 }
 
 export function copy(source, target) {
-  fs.createReadStream(source).pipe(fs.createWriteStream(target))
+  fs.copyFileSync(source, target)
 }
 
 /**

--- a/test/src/utils/FileSystem.test.js
+++ b/test/src/utils/FileSystem.test.js
@@ -6,19 +6,49 @@ import FileSystem from '../../../src/utils/FileSystem'
 
 contract('FileSystem', () => {
   it('can remove an empty directory', async function () {
-    var testDir = tmp.dirSync()
+    const testDir = tmp.dirSync()
     FileSystem.exists(testDir.name).should.be.true
     FileSystem.removeTree(testDir.name)
     FileSystem.exists(testDir.name).should.be.false
   })
 
   it('can remove a non-empty directory', async function () {
-    var testDir = tmp.dirSync()
-    var testFilePath = `${testDir.name}/testfile`
+    const testDir = tmp.dirSync()
+    const testFilePath = `${testDir.name}/testfile`
     FileSystem.write(testFilePath, 'dummy')
     FileSystem.exists(testFilePath).should.be.true
     FileSystem.removeTree(testDir.name)
     FileSystem.exists(testDir.name).should.be.false
   })
 
+  it('can copy a file when the destination does not exist', function() {
+    const testDir = tmp.dirSync()
+    const sourceFilePath = `${testDir.name}/test`
+    const destinationFilePath = `${testDir.name}/testCopy`
+    FileSystem.write(sourceFilePath, 'Hello, World!')
+
+    FileSystem.copy(sourceFilePath, destinationFilePath)
+
+    const source = FileSystem.read(sourceFilePath).toString()
+    const destination = FileSystem.read(destinationFilePath).toString()
+    source.should.equal(destination)
+
+    FileSystem.removeTree(testDir.name)
+  })
+
+  it('can copy a file when the destination already exists', function () {
+    const testDir = tmp.dirSync()
+    const sourceFilePath = `${testDir.name}/test`
+    const destinationFilePath = `${testDir.name}/testCopy`
+    FileSystem.write(sourceFilePath, 'Hello, World!')
+    FileSystem.write(destinationFilePath, 'Foobar')
+
+    FileSystem.copy(sourceFilePath, destinationFilePath)
+
+    const source = FileSystem.read(sourceFilePath).toString()
+    const destination = FileSystem.read(destinationFilePath).toString()
+    source.should.equal(destination)
+
+    FileSystem.removeTree(testDir.name)
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos-cli/issues/208

Make `copy` function synchronous by using [`copyFileSync`](https://nodejs.org/api/fs.html#fs_fs_copyfilesync_src_dest_flags) function.