### PR TITLE
Update solc to version 4 24

### DIFF
--- a/contracts/application/AppDirectory.sol
+++ b/contracts/application/AppDirectory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "./versioning/ImplementationProvider.sol";
 import "./versioning/ImplementationDirectory.sol";

--- a/contracts/application/AppDirectory.sol
+++ b/contracts/application/AppDirectory.sol
@@ -26,7 +26,7 @@ contract AppDirectory is ImplementationDirectory {
    * @dev Constructor function.
    * @param _stdlib Provider for standard library implementations.
    */
-  function AppDirectory(ImplementationProvider _stdlib) public {
+  constructor(ImplementationProvider _stdlib) public {
     stdlib = _stdlib;
   }
 

--- a/contracts/application/BaseApp.sol
+++ b/contracts/application/BaseApp.sol
@@ -18,7 +18,7 @@ contract BaseApp is Ownable {
    * @dev Constructor function
    * @param _factory Proxy factory
    */
-  function BaseApp(UpgradeabilityProxyFactory _factory) public {
+  constructor(UpgradeabilityProxyFactory _factory) public {
     require(address(_factory) != address(0));
     factory = _factory;
   }

--- a/contracts/application/BaseApp.sol
+++ b/contracts/application/BaseApp.sol
@@ -19,7 +19,7 @@ contract BaseApp is Ownable {
    * @param _factory Proxy factory
    */
   constructor(UpgradeabilityProxyFactory _factory) public {
-    require(address(_factory) != address(0));
+    require(address(_factory) != address(0), "Cannot set the proxy factory of an app to the zero address");
     factory = _factory;
   }
 

--- a/contracts/application/BaseApp.sol
+++ b/contracts/application/BaseApp.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "./versioning/ImplementationProvider.sol";
 import "../upgradeability/AdminUpgradeabilityProxy.sol";

--- a/contracts/application/PackagedApp.sol
+++ b/contracts/application/PackagedApp.sol
@@ -22,8 +22,8 @@ contract PackagedApp is BaseApp {
    * @param _factory Proxy factory.
    */
   constructor(Package _package, string _version, UpgradeabilityProxyFactory _factory) BaseApp(_factory) public {
-    require(address(_package) != address(0));
-    require(_package.hasVersion(_version));
+    require(address(_package) != address(0), "Cannot set the package of an app to the zero address");
+    require(_package.hasVersion(_version), "The requested version must be registered in the given package");
     package = _package;
     version = _version;
   }
@@ -34,7 +34,7 @@ contract PackagedApp is BaseApp {
    * @param newVersion Name of the new version.
    */
   function setVersion(string newVersion) public onlyOwner {
-    require(package.hasVersion(newVersion));
+    require(package.hasVersion(newVersion), "The requested version must be registered in the given package");
     version = newVersion;
   }
 

--- a/contracts/application/PackagedApp.sol
+++ b/contracts/application/PackagedApp.sol
@@ -21,10 +21,7 @@ contract PackagedApp is BaseApp {
    * @param _version Initial version of the app.
    * @param _factory Proxy factory.
    */
-  function PackagedApp(Package _package, string _version, UpgradeabilityProxyFactory _factory)
-    BaseApp(_factory)
-    public
-  {
+  constructor(Package _package, string _version, UpgradeabilityProxyFactory _factory) BaseApp(_factory) public {
     require(address(_package) != address(0));
     require(_package.hasVersion(_version));
     package = _package;

--- a/contracts/application/PackagedApp.sol
+++ b/contracts/application/PackagedApp.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "./BaseApp.sol";
 import "./versioning/Package.sol";

--- a/contracts/application/UnversionedApp.sol
+++ b/contracts/application/UnversionedApp.sol
@@ -36,7 +36,7 @@ contract UnversionedApp is BaseApp {
    * @param _provider New implementation provider
    */
   function setProvider(ImplementationProvider _provider) public onlyOwner {
-    require(address(_provider) != address(0));
+    require(address(_provider) != address(0), "Cannot set the implementation provider of an app to the zero address");
     provider = _provider;
   }
 }

--- a/contracts/application/UnversionedApp.sol
+++ b/contracts/application/UnversionedApp.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "./BaseApp.sol";
 import "./versioning/ImplementationProvider.sol";

--- a/contracts/application/UnversionedApp.sol
+++ b/contracts/application/UnversionedApp.sol
@@ -19,10 +19,7 @@ contract UnversionedApp is BaseApp {
    * @param _provider Implementation provider.
    * @param _factory Proxy factory.
    */
-  function UnversionedApp(ImplementationProvider _provider, UpgradeabilityProxyFactory _factory)
-    BaseApp(_factory)
-    public
-  {
+  constructor(ImplementationProvider _provider, UpgradeabilityProxyFactory _factory) BaseApp(_factory) public {
     setProvider(_provider);
   }
 

--- a/contracts/application/versioning/FreezableImplementationDirectory.sol
+++ b/contracts/application/versioning/FreezableImplementationDirectory.sol
@@ -14,7 +14,7 @@ contract FreezableImplementationDirectory is ImplementationDirectory {
    * @dev Modifier that allows functions to be called only before the contract is frozen.
    */
   modifier whenNotFrozen() {
-    require(!frozen);
+    require(!frozen, "Cannot perform action for a frozen implementation directory");
     _;
   }
 

--- a/contracts/application/versioning/FreezableImplementationDirectory.sol
+++ b/contracts/application/versioning/FreezableImplementationDirectory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "./ImplementationDirectory.sol";
 

--- a/contracts/application/versioning/ImplementationDirectory.sol
+++ b/contracts/application/versioning/ImplementationDirectory.sol
@@ -34,7 +34,7 @@ contract ImplementationDirectory is ImplementationProvider, Ownable {
    * @param implementation Address of the implementation.
    */
   function setImplementation(string contractName, address implementation) public onlyOwner {
-    require(AddressUtils.isContract(implementation));
+    require(AddressUtils.isContract(implementation), "Cannot set implementation in directory with a non-contract address");
     implementations[contractName] = implementation;
     emit ImplementationChanged(contractName, implementation);
   }

--- a/contracts/application/versioning/ImplementationDirectory.sol
+++ b/contracts/application/versioning/ImplementationDirectory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "./ImplementationProvider.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";

--- a/contracts/application/versioning/ImplementationProvider.sol
+++ b/contracts/application/versioning/ImplementationProvider.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 /**
  * @title ImplementationProvider

--- a/contracts/application/versioning/Package.sol
+++ b/contracts/application/versioning/Package.sol
@@ -38,7 +38,7 @@ contract Package is Ownable {
    * @param provider ImplementationProvider associated with the version.
    */
   function addVersion(string version, ImplementationProvider provider) public onlyOwner {
-    require(!hasVersion(version));
+    require(!hasVersion(version), "Given version is already registered in package");
     versions[version] = provider;
     emit VersionAdded(version, provider);
   }

--- a/contracts/application/versioning/Package.sol
+++ b/contracts/application/versioning/Package.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "./ImplementationProvider.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";

--- a/contracts/application/versioning/Release.sol
+++ b/contracts/application/versioning/Release.sol
@@ -19,7 +19,7 @@ contract Release is FreezableImplementationDirectory {
    * @dev Constructor function.
    * It sets the `msg.sender` as the developer of this release.
    */
-  function Release() public {
+  constructor() public {
     developer = msg.sender;
   }
 }

--- a/contracts/application/versioning/Release.sol
+++ b/contracts/application/versioning/Release.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "./FreezableImplementationDirectory.sol";
 

--- a/contracts/migrations/Initializable.sol
+++ b/contracts/migrations/Initializable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 
 /**

--- a/contracts/migrations/Initializable.sol
+++ b/contracts/migrations/Initializable.sol
@@ -22,7 +22,7 @@ contract Initializable {
    * @dev Modifier to use in the initialization function of a contract.
    */
   modifier isInitializer() {
-    require(!initialized);
+    require(!initialized, "Contract instance has already been initialized");
     _;
     initialized = true;
   }

--- a/contracts/migrations/Migratable.sol
+++ b/contracts/migrations/Migratable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 
 /**

--- a/contracts/migrations/Migratable.sol
+++ b/contracts/migrations/Migratable.sol
@@ -41,8 +41,8 @@ contract Migratable {
    * @param migrationId Identifier of the migration.
    */
   modifier isInitializer(string contractName, string migrationId) {
-    require(!isMigrated(contractName, INITIALIZED_ID));
-    require(!isMigrated(contractName, migrationId));
+    validateMigrationIsPending(contractName, INITIALIZED_ID);
+    validateMigrationIsPending(contractName, migrationId);
     _;
     emit Migrated(contractName, migrationId);
     migrated[contractName][migrationId] = true;
@@ -57,7 +57,8 @@ contract Migratable {
    * @param newMigrationId Identifier of the new migration to be applied.
    */
   modifier isMigration(string contractName, string requiredMigrationId, string newMigrationId) {
-    require(isMigrated(contractName, requiredMigrationId) && !isMigrated(contractName, newMigrationId));
+    require(isMigrated(contractName, requiredMigrationId), "Prerequisite migration ID has not been run yet");
+    validateMigrationIsPending(contractName, newMigrationId);
     _;
     emit Migrated(contractName, newMigrationId);
     migrated[contractName][newMigrationId] = true;
@@ -78,6 +79,15 @@ contract Migratable {
    * It is important to run this if you had deployed a previous version of a Migratable contract.
    * For more information see https://github.com/zeppelinos/zos-lib/issues/158.
    */
-  function initialize() isInitializer("Migratable", "1.2.1") {
+  function initialize() isInitializer("Migratable", "1.2.1") public {
+  }
+
+  /**
+   * @dev Reverts if the requested migration was already executed.
+   * @param contractName Name of the contract.
+   * @param migrationId Identifier of the migration.
+   */
+  function validateMigrationIsPending(string contractName, string migrationId) private {
+    require(!isMigrated(contractName, migrationId), "Requested target migration ID has already been run");
   }
 }

--- a/contracts/mocks/ClashingImplementation.sol
+++ b/contracts/mocks/ClashingImplementation.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 
 /**

--- a/contracts/mocks/DummyImplementation.sol
+++ b/contracts/mocks/DummyImplementation.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 contract Impl {
   function version() public pure returns (string); 

--- a/contracts/mocks/InitializableMock.sol
+++ b/contracts/mocks/InitializableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "../migrations/Initializable.sol";
 
@@ -8,7 +8,6 @@ import "../migrations/Initializable.sol";
  */
 contract InitializableMock is Initializable {
 
-  function initialize() public isInitializer {
-  }
+  function initialize() public isInitializer {}
 
 }

--- a/contracts/mocks/MigratableMock.sol
+++ b/contracts/mocks/MigratableMock.sol
@@ -14,7 +14,7 @@ contract MigratableMock is Migratable {
   }
 
   function fail() public pure {
-    require(false);
+    require(false, "MigratableMock forced failure");
   }
 
   function secondInitialize() public isInitializer("MigratableMock", "1") {

--- a/contracts/mocks/MigratableMock.sol
+++ b/contracts/mocks/MigratableMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "../migrations/Migratable.sol";
 
@@ -8,8 +8,6 @@ import "../migrations/Migratable.sol";
  */
 contract MigratableMock is Migratable {
   uint256 public x;
-
-  function MigratableMock() public {}
 
   function initialize(uint256 value) public payable isInitializer("MigratableMock", "0") {
     x = value;

--- a/contracts/mocks/MultipleInheritanceMigratableMocks.sol
+++ b/contracts/mocks/MultipleInheritanceMigratableMocks.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import '../migrations/Migratable.sol';
 

--- a/contracts/mocks/RegressionImplementation.sol
+++ b/contracts/mocks/RegressionImplementation.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "../migrations/Initializable.sol";
 

--- a/contracts/mocks/SingleInheritanceMigratableMocks.sol
+++ b/contracts/mocks/SingleInheritanceMigratableMocks.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import '../migrations/Migratable.sol';
 

--- a/contracts/upgradeability/AdminUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/AdminUpgradeabilityProxy.sol
@@ -43,7 +43,7 @@ contract AdminUpgradeabilityProxy is UpgradeabilityProxy {
    * It sets the `msg.sender` as the proxy administrator.
    * @param _implementation address of the initial implementation.
    */
-  function AdminUpgradeabilityProxy(address _implementation) UpgradeabilityProxy(_implementation) public {
+  constructor(address _implementation) UpgradeabilityProxy(_implementation) public {
     assert(ADMIN_SLOT == keccak256("org.zeppelinos.proxy.admin"));
 
     _setAdmin(msg.sender);

--- a/contracts/upgradeability/AdminUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/AdminUpgradeabilityProxy.sol
@@ -87,24 +87,24 @@ contract AdminUpgradeabilityProxy is UpgradeabilityProxy {
    * @dev Upgrade the backing implementation of the proxy and call a function
    * on the new implementation.
    * This is useful to initialize the proxied contract.
-   * @param implementation Address of the new implementation.
+   * @param newImplementation Address of the new implementation.
    * @param data Data to send as msg.data in the low level call.
    * It should include the signature and the parameters of the function to be
    * called, as described in
    * https://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector-and-argument-encoding.
    */
-  function upgradeToAndCall(address implementation, bytes data) payable external ifAdmin {
-    _upgradeTo(implementation);
+  function upgradeToAndCall(address newImplementation, bytes data) payable external ifAdmin {
+    _upgradeTo(newImplementation);
     require(address(this).call.value(msg.value)(data));
   }
 
   /**
    * @return The admin slot.
    */
-  function _admin() internal returns (address admin) {
+  function _admin() internal view returns (address adm) {
     bytes32 slot = ADMIN_SLOT;
     assembly {
-      admin := sload(slot)
+      adm := sload(slot)
     }
   }
 

--- a/contracts/upgradeability/AdminUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/AdminUpgradeabilityProxy.sol
@@ -69,7 +69,7 @@ contract AdminUpgradeabilityProxy is UpgradeabilityProxy {
    * @param newAdmin Address to transfer proxy administration to.
    */
   function changeAdmin(address newAdmin) external ifAdmin {
-    require(newAdmin != address(0));
+    require(newAdmin != address(0), "Cannot change the admin of a proxy to the zero address");
     emit AdminChanged(_admin(), newAdmin);
     _setAdmin(newAdmin);
   }
@@ -124,7 +124,7 @@ contract AdminUpgradeabilityProxy is UpgradeabilityProxy {
    * @dev Only fall back when the sender is not the admin.
    */
   function _willFallback() internal {
-    require(msg.sender != _admin());
+    require(msg.sender != _admin(), "Cannot call fallback function from the proxy admin");
     super._willFallback();
   }
 }

--- a/contracts/upgradeability/AdminUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/AdminUpgradeabilityProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import './UpgradeabilityProxy.sol';
 

--- a/contracts/upgradeability/Proxy.sol
+++ b/contracts/upgradeability/Proxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 /**
  * @title Proxy

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import './Proxy.sol';
 import 'openzeppelin-solidity/contracts/AddressUtils.sol';

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -27,7 +27,7 @@ contract UpgradeabilityProxy is Proxy {
    * @dev Contract constructor.
    * @param _implementation Address of the initial implementation.
    */
-  function UpgradeabilityProxy(address _implementation) public {
+  constructor(address _implementation) public {
     assert(IMPLEMENTATION_SLOT == keccak256("org.zeppelinos.proxy.implementation"));
 
     _setImplementation(_implementation);

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -58,7 +58,7 @@ contract UpgradeabilityProxy is Proxy {
    * @param newImplementation Address of the new implementation.
    */
   function _setImplementation(address newImplementation) private {
-    require(AddressUtils.isContract(newImplementation));
+    require(AddressUtils.isContract(newImplementation), "Cannot set a proxy implementation to a non-contract address");
 
     bytes32 slot = IMPLEMENTATION_SLOT;
 

--- a/contracts/upgradeability/UpgradeabilityProxyFactory.sol
+++ b/contracts/upgradeability/UpgradeabilityProxyFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import './AdminUpgradeabilityProxy.sol';
 

--- a/examples/complex/.babelrc
+++ b/examples/complex/.babelrc
@@ -1,3 +1,10 @@
 {
-  "presets": ["es2015", "stage-2", "stage-3"],
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": "8.9"
+      }
+    }]
+  ],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/examples/complex/package-lock.json
+++ b/examples/complex/package-lock.json
@@ -4,6 +4,17 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -51,17 +62,6 @@
         "private": "^0.1.8",
         "slash": "^1.0.0",
         "source-map": "^0.5.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "babel-generator": {
@@ -644,6 +644,52 @@
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
         "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-preset-es2015": {
@@ -726,14 +772,6 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        }
       }
     },
     "babel-template": {
@@ -789,6 +827,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+    },
+    "bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -803,6 +851,16 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
     },
+    "browserslist": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
+      }
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -812,6 +870,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000862",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000862.tgz",
+      "integrity": "sha512-e9DBeH0Oby7EbUQN3DRWKxgbpEJO3KAZUhP0xDmPA23Qr6PmvXI7Ojy8ZthsOsz+1iSoaV9G7eWJXUOyryJ6NA==",
+      "dev": true
     },
     "chalk": {
       "version": "1.1.3",
@@ -824,14 +888,6 @@
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "cliui": {
@@ -844,18 +900,20 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "requires": {
-        "graceful-readlink": ">= 1.0.0"
-      }
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -869,15 +927,21 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+    },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -897,19 +961,20 @@
       }
     },
     "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
     },
-    "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+    "electron-to-chromium": {
+      "version": "1.3.51",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.51.tgz",
+      "integrity": "sha1-akK0nar38ipbN7mR2vlJ8029ubU=",
+      "dev": true
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -924,6 +989,26 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "ethjs-abi": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
+      "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "find-up": {
       "version": "1.1.2",
@@ -957,14 +1042,14 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.2",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -980,15 +1065,10 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-    },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -1000,9 +1080,9 @@
       }
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "he": {
       "version": "1.1.1",
@@ -1020,9 +1100,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
+      "integrity": "sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1082,10 +1162,20 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "is-hex-prefixed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "js-sha3": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+      "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -1099,10 +1189,10 @@
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json5": {
       "version": "0.5.1",
@@ -1152,69 +1242,10 @@
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "requires": {
-        "lodash._baseassign": "^3.0.0",
-        "lodash._basecreate": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -1259,22 +1290,38 @@
       }
     },
     "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
       "requires": {
         "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
         "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
       }
     },
     "ms": {
@@ -1298,6 +1345,15 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
+    "number-to-bn": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "strip-hex-prefix": "1.0.0"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1307,25 +1363,32 @@
       }
     },
     "openzeppelin-solidity": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.9.0.tgz",
-      "integrity": "sha512-MGI8clDbjrfWUg90AM82O+CHOaabtE2u9HyaUhBMKfWdIaO1urRUIgXIrEuloLvFEBHb5rtcgTARb5DkhUB4KQ=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
+      "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg=="
     },
     "openzeppelin-zos": {
-      "version": "1.9.0-beta",
-      "resolved": "https://registry.npmjs.org/openzeppelin-zos/-/openzeppelin-zos-1.9.0-beta.tgz",
-      "integrity": "sha512-PsiNRj1zSmSrCe2ARIAt+x1AdJNY53jOnhzHw0a6n37tOmyY6RJJNUv43A5CPAbMR/WWN6eawCjG5IZWbcYuhQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/openzeppelin-zos/-/openzeppelin-zos-1.9.1.tgz",
+      "integrity": "sha512-5USin/aK2pR2kG44DC0H4LUJyOijCRTTb2BIFWR990rlP6FU9azuMnKOWvGoTvlsshPaORqsAc/bTEPoGKKm4g==",
       "requires": {
-        "dotenv": "^4.0.0",
-        "zos-lib": "0.0.5"
+        "zos-lib": "^0.1.26"
       },
       "dependencies": {
+        "openzeppelin-solidity": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.9.0.tgz",
+          "integrity": "sha512-MGI8clDbjrfWUg90AM82O+CHOaabtE2u9HyaUhBMKfWdIaO1urRUIgXIrEuloLvFEBHb5rtcgTARb5DkhUB4KQ=="
+        },
         "zos-lib": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/zos-lib/-/zos-lib-0.0.5.tgz",
-          "integrity": "sha512-UVINaUZ9WuGGlljKaTXaxzaLGW9F/5AViSsOYy/oagFyQIY6Ch9WQ1fnUx3L8O4p1XGne9rG2JXY4B9f6YPHsA==",
+          "version": "0.1.28",
+          "resolved": "https://registry.npmjs.org/zos-lib/-/zos-lib-0.1.28.tgz",
+          "integrity": "sha512-zrhDM9HdgbX4nyHoNQbfBrZB8zVSCt9AUu2AxQUpIoeVsa8Q7nFfjf+HjWQYgefZU2ENi7oskEkE8g7A0QrXIA==",
           "requires": {
-            "zeppelin-solidity": "^1.8.0"
+            "bignumber.js": "^7.2.0",
+            "openzeppelin-solidity": "~1.9.0",
+            "truffle-contract": "^3.0.5",
+            "truffle-provisioner": "^0.1.0"
           }
         }
       }
@@ -1436,9 +1499,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regenerator-transform": {
@@ -1527,9 +1590,9 @@
       "dev": true
     },
     "solc": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.23.tgz",
-      "integrity": "sha512-AT7anLHY6uIRg2It6N0UlCHeZ7YeecIkUhnlirrCgCPCUevtnoN48BxvgigN/4jJTRljv5oFhAJtI6gvHzT5DQ==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
+      "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
       "requires": {
         "fs-extra": "^0.30.0",
         "memorystream": "^0.3.1",
@@ -1607,13 +1670,19 @@
         "is-utf8": "^0.2.0"
       }
     },
-    "supports-color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+    "strip-hex-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
       "requires": {
-        "has-flag": "^1.0.0"
+        "is-hex-prefixed": "1.0.0"
       }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -1628,14 +1697,66 @@
       "dev": true
     },
     "truffle": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.8.tgz",
-      "integrity": "sha512-btDML3J9Ao+UDqR725ajTybcEqyXzxFzJDC/NAXOyOXoXf2HJwKq6VEvnjP9qc6owA+fJ50d87MmsPRXk+riCg==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.13.tgz",
+      "integrity": "sha1-vydYaYi0/4RWPt+/MrR5QUCKdq0=",
       "requires": {
-        "mocha": "^3.4.2",
-        "original-require": "^1.0.1",
-        "solc": "0.4.23"
+        "mocha": "^4.1.0",
+        "original-require": "1.0.1",
+        "solc": "0.4.24"
       }
+    },
+    "truffle-blockchain-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.5.tgz",
+      "integrity": "sha1-pOXAZNrdafeCoTfz0nbSEJXaekc="
+    },
+    "truffle-contract": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.6.tgz",
+      "integrity": "sha1-Lvb8Mtf6r6n0rtjlAAGp/eo0IZI=",
+      "requires": {
+        "ethjs-abi": "0.1.8",
+        "truffle-blockchain-utils": "^0.0.5",
+        "truffle-contract-schema": "^2.0.1",
+        "truffle-error": "^0.0.3",
+        "web3": "0.20.6"
+      }
+    },
+    "truffle-contract-schema": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.1.tgz",
+      "integrity": "sha1-m/gh0y4m5nS6FetdQPlrELHJ1Wg=",
+      "requires": {
+        "ajv": "^5.1.1",
+        "crypto-js": "^3.1.9-1",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "truffle-error": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.3.tgz",
+      "integrity": "sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o="
+    },
+    "truffle-provisioner": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/truffle-provisioner/-/truffle-provisioner-0.1.1.tgz",
+      "integrity": "sha1-WoMn1iUR7yPJUNOqhiYQp8N34qo="
+    },
+    "utf8": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
     },
     "validate-npm-package-license": {
       "version": "3.0.3",
@@ -1644,6 +1765,29 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "web3": {
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+      "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
+      "requires": {
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+        "crypto-js": "^3.1.4",
+        "utf8": "^2.1.1",
+        "xhr2": "*",
+        "xmlhttprequest": "*"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+        },
+        "crypto-js": {
+          "version": "3.1.8",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
+          "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
+        }
       }
     },
     "which-module": {
@@ -1669,6 +1813,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xhr2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
+      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "y18n": {
       "version": "3.2.1",
@@ -1705,18 +1859,16 @@
         "lodash.assign": "^4.0.6"
       }
     },
-    "zeppelin-solidity": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/zeppelin-solidity/-/zeppelin-solidity-1.9.0.tgz",
-      "integrity": "sha512-pdyPVyjDq7cNqqLps9juDNDkKCa6hSafEm8KyzPw+gNYTiDyG1H4sYVFuBGp03iqxlGhsacrstbps5/AHTxBUg=="
-    },
     "zos-lib": {
       "version": "file:../..",
       "requires": {
         "bignumber.js": "^7.2.0",
-        "openzeppelin-solidity": "~1.9.0",
-        "truffle-contract": "^3.0.5",
-        "truffle-provisioner": "^0.1.0"
+        "chalk": "^2.4.1",
+        "ethereumjs-abi": "^0.6.5",
+        "openzeppelin-solidity": "^1.10.0",
+        "truffle-contract": "^3.0.6",
+        "truffle-provisioner": "^0.1.1",
+        "web3": "^0.18.4"
       },
       "dependencies": {
         "@mrmlnc/readdir-enhanced": {
@@ -2974,6 +3126,7 @@
           "requires": {
             "anymatch": "^1.3.0",
             "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
             "glob-parent": "^2.0.0",
             "inherits": "^2.0.1",
             "is-binary-path": "^1.0.0",
@@ -3125,11 +3278,8 @@
           }
         },
         "commander": {
-          "version": "2.9.0",
-          "bundled": true,
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
+          "version": "2.11.0",
+          "bundled": true
         },
         "commondir": {
           "version": "1.0.1",
@@ -3346,7 +3496,7 @@
           }
         },
         "diff": {
-          "version": "3.2.0",
+          "version": "3.3.1",
           "bundled": true
         },
         "dir-glob": {
@@ -3525,6 +3675,25 @@
             "keccakjs": "^0.2.0",
             "rlp": "^2.0.0",
             "secp256k1": "^3.0.1"
+          }
+        },
+        "ethjs-abi": {
+          "version": "0.1.8",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "js-sha3": "0.5.5",
+            "number-to-bn": "1.7.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "bundled": true
+            },
+            "js-sha3": {
+              "version": "0.5.5",
+              "bundled": true
+            }
           }
         },
         "evp_bytestokey": {
@@ -4000,6 +4169,467 @@
           "version": "1.0.0",
           "bundled": true
         },
+        "fsevents": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.5.1",
+              "bundled": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.21",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": "^2.1.0"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.2.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.0",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.5.1",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.0.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.2.4",
+                "minizlib": "^1.1.0",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
         "get-caller-file": {
           "version": "1.0.2",
           "bundled": true
@@ -4220,10 +4850,6 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
           "bundled": true
         },
         "grouped-queue": {
@@ -4883,10 +5509,6 @@
           "version": "5.0.1",
           "bundled": true
         },
-        "json3": {
-          "version": "3.3.2",
-          "bundled": true
-        },
         "json5": {
           "version": "0.5.1",
           "bundled": true
@@ -5174,59 +5796,9 @@
           "version": "4.17.5",
           "bundled": true
         },
-        "lodash._baseassign": {
-          "version": "3.2.0",
-          "bundled": true,
-          "requires": {
-            "lodash._basecopy": "^3.0.0",
-            "lodash.keys": "^3.0.0"
-          }
-        },
-        "lodash._basecopy": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "lodash._basecreate": {
-          "version": "3.0.3",
-          "bundled": true
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "bundled": true
-        },
-        "lodash._isiterateecall": {
-          "version": "3.0.9",
-          "bundled": true
-        },
         "lodash.assign": {
           "version": "4.2.0",
           "bundled": true
-        },
-        "lodash.create": {
-          "version": "3.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash._baseassign": "^3.0.0",
-            "lodash._basecreate": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0"
-          }
-        },
-        "lodash.isarguments": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "lodash._getnative": "^3.0.0",
-            "lodash.isarguments": "^3.0.0",
-            "lodash.isarray": "^3.0.0"
-          }
         },
         "log-driver": {
           "version": "1.2.7",
@@ -5498,28 +6070,53 @@
           }
         },
         "mocha": {
-          "version": "3.5.3",
+          "version": "4.1.0",
           "bundled": true,
           "requires": {
             "browser-stdout": "1.3.0",
-            "commander": "2.9.0",
-            "debug": "2.6.8",
-            "diff": "3.2.0",
+            "commander": "2.11.0",
+            "debug": "3.1.0",
+            "diff": "3.3.1",
             "escape-string-regexp": "1.0.5",
-            "glob": "7.1.1",
-            "growl": "1.9.2",
+            "glob": "7.1.2",
+            "growl": "1.10.3",
             "he": "1.1.1",
-            "json3": "3.3.2",
-            "lodash.create": "3.1.1",
             "mkdirp": "0.5.1",
-            "supports-color": "3.1.2"
+            "supports-color": "4.4.0"
           },
           "dependencies": {
             "debug": {
-              "version": "2.6.8",
+              "version": "3.1.0",
               "bundled": true,
               "requires": {
                 "ms": "2.0.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "growl": {
+              "version": "1.10.3",
+              "bundled": true
+            },
+            "has-flag": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "4.4.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^2.0.0"
               }
             }
           }
@@ -5757,7 +6354,7 @@
           }
         },
         "openzeppelin-solidity": {
-          "version": "1.9.0",
+          "version": "1.10.0",
           "bundled": true
         },
         "optimist": {
@@ -6621,7 +7218,7 @@
           "bundled": true
         },
         "solc": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "requires": {
             "fs-extra": "^0.30.0",
@@ -7001,49 +7598,32 @@
           "bundled": true
         },
         "truffle": {
-          "version": "4.1.5",
+          "version": "4.1.13",
           "bundled": true,
           "requires": {
-            "mocha": "^3.4.2",
-            "original-require": "^1.0.1",
-            "solc": "0.4.21"
+            "mocha": "^4.1.0",
+            "original-require": "1.0.1",
+            "solc": "0.4.24"
           }
         },
         "truffle-blockchain-utils": {
-          "version": "0.0.4",
+          "version": "0.0.5",
           "bundled": true
         },
         "truffle-contract": {
-          "version": "3.0.5",
+          "version": "3.0.6",
           "bundled": true,
           "requires": {
             "ethjs-abi": "0.1.8",
-            "truffle-blockchain-utils": "^0.0.4",
-            "truffle-contract-schema": "^2.0.0",
-            "truffle-error": "0.0.2",
-            "web3": "^0.20.1"
+            "truffle-blockchain-utils": "^0.0.5",
+            "truffle-contract-schema": "^2.0.1",
+            "truffle-error": "^0.0.3",
+            "web3": "0.20.6"
           },
           "dependencies": {
             "bignumber.js": {
               "version": "2.0.7",
               "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "bundled": true
-            },
-            "bn.js": {
-              "version": "4.11.6",
-              "bundled": true
-            },
-            "ethjs-abi": {
-              "version": "0.1.8",
-              "bundled": true,
-              "requires": {
-                "bn.js": "4.11.6",
-                "js-sha3": "0.5.5",
-                "number-to-bn": "1.7.0"
-              }
-            },
-            "js-sha3": {
-              "version": "0.5.5",
               "bundled": true
             },
             "web3": {
@@ -7067,7 +7647,7 @@
           }
         },
         "truffle-contract-schema": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "requires": {
             "ajv": "^5.1.1",
@@ -7089,11 +7669,11 @@
           }
         },
         "truffle-error": {
-          "version": "0.0.2",
+          "version": "0.0.3",
           "bundled": true
         },
         "truffle-provisioner": {
-          "version": "0.1.0",
+          "version": "0.1.1",
           "bundled": true
         },
         "tunnel-agent": {
@@ -7347,10 +7927,18 @@
           "version": "0.18.4",
           "bundled": true,
           "requires": {
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "2.0.7",
+              "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+              "bundled": true
+            }
           }
         },
         "webpack-addons": {

--- a/examples/complex/package.json
+++ b/examples/complex/package.json
@@ -19,16 +19,17 @@
   "license": "ISC",
   "dependencies": {
     "minimist": "^1.2.0",
-    "openzeppelin-solidity": "~1.9.0",
-    "openzeppelin-zos": "^1.9.0-beta",
-    "truffle": "^4.1.5",
+    "openzeppelin-solidity": "~1.10.0",
+    "openzeppelin-zos": "~1.9.1",
+    "truffle": "^4.1.13",
     "zos-lib": "file:../.."
   },
   "devDependencies": {
-    "babel-register": "^6.26.0",
     "babel-polyfill": "^6.23.0",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
-    "babel-preset-stage-3": "^6.24.1"
+    "babel-preset-stage-3": "^6.24.1",
+    "babel-register": "^6.26.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6309,9 +6309,9 @@
       }
     },
     "openzeppelin-solidity": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.9.0.tgz",
-      "integrity": "sha512-MGI8clDbjrfWUg90AM82O+CHOaabtE2u9HyaUhBMKfWdIaO1urRUIgXIrEuloLvFEBHb5rtcgTARb5DkhUB4KQ=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
+      "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg=="
     },
     "optimist": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2295,6 +2295,28 @@
         "secp256k1": "^3.0.1"
       }
     },
+    "ethjs-abi": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
+      "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
+        }
+      }
+    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -7912,56 +7934,36 @@
       "dev": true
     },
     "truffle": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.11.tgz",
-      "integrity": "sha512-VNhc6jexZeM92sNJJr4U8ln3uJ/mJEQO/0y9ZLYc4pccyIskPtl+3r4mzymgGM/Mq5v6MpoQVD6NZgHUVKX+Dw==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.13.tgz",
+      "integrity": "sha1-vydYaYi0/4RWPt+/MrR5QUCKdq0=",
       "dev": true,
       "requires": {
         "mocha": "^4.1.0",
-        "original-require": "^1.0.1",
+        "original-require": "1.0.1",
         "solc": "0.4.24"
       }
     },
     "truffle-blockchain-utils": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.4.tgz",
-      "integrity": "sha512-wgRrhwqh0aea08Hz28hUV4tuF2uTVQH/e9kBou+WK04cqrutB5cxQVQ6HGjeZLltxBYOFvhrGOOq4l3WJFnPEA=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.5.tgz",
+      "integrity": "sha1-pOXAZNrdafeCoTfz0nbSEJXaekc="
     },
     "truffle-contract": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.5.tgz",
-      "integrity": "sha512-lRayhvX73OrLJ6TDvc0iYbzcB+Y1F9FCj9N1FXQ2EKOkqyIjmgZNMZFHGjvfTws1gsmonYd6sND0ahipiUYy8g==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.6.tgz",
+      "integrity": "sha1-Lvb8Mtf6r6n0rtjlAAGp/eo0IZI=",
       "requires": {
         "ethjs-abi": "0.1.8",
-        "truffle-blockchain-utils": "^0.0.4",
-        "truffle-contract-schema": "^2.0.0",
-        "truffle-error": "0.0.2",
-        "web3": "^0.20.1"
+        "truffle-blockchain-utils": "^0.0.5",
+        "truffle-contract-schema": "^2.0.1",
+        "truffle-error": "^0.0.3",
+        "web3": "0.20.6"
       },
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-        },
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "ethjs-abi": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
-          "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "js-sha3": "0.5.5",
-            "number-to-bn": "1.7.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
         },
         "web3": {
           "version": "0.20.6",
@@ -7973,20 +7975,14 @@
             "utf8": "^2.1.1",
             "xhr2": "*",
             "xmlhttprequest": "*"
-          },
-          "dependencies": {
-            "bignumber.js": {
-              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-            }
           }
         }
       }
     },
     "truffle-contract-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.0.tgz",
-      "integrity": "sha512-nLlspmu1GKDaluWksBwitHi/7Z3IpRjmBYeO9N+T1nVJD2V4IWJaptCKP1NqnPiJA+FChB7+F7pI6Br51/FtXQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.1.tgz",
+      "integrity": "sha1-m/gh0y4m5nS6FetdQPlrELHJ1Wg=",
       "requires": {
         "ajv": "^5.1.1",
         "crypto-js": "^3.1.9-1",
@@ -8009,14 +8005,14 @@
       }
     },
     "truffle-error": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.2.tgz",
-      "integrity": "sha1-AbGJt4UFVmrhaJwjnHyi3RIc/kw="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.3.tgz",
+      "integrity": "sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o="
     },
     "truffle-provisioner": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/truffle-provisioner/-/truffle-provisioner-0.1.0.tgz",
-      "integrity": "sha1-Ap5SScEBUwBzhTXgT97ZMaU8T2I="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/truffle-provisioner/-/truffle-provisioner-0.1.1.tgz",
+      "integrity": "sha1-WoMn1iUR7yPJUNOqhiYQp8N34qo="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bignumber.js": "^7.2.0",
     "chalk": "^2.4.1",
     "ethereumjs-abi": "^0.6.5",
-    "openzeppelin-solidity": "~1.9.0",
+    "openzeppelin-solidity": "~1.10.0",
     "truffle-contract": "^3.0.6",
     "truffle-provisioner": "^0.1.1",
     "web3": "^0.18.4"

--- a/package.json
+++ b/package.json
@@ -48,15 +48,15 @@
     "mock-dependency": "file:test/mocks/mock-dependency",
     "solidity-coverage": "^0.4.15",
     "tmp": "^0.0.33",
-    "truffle": "^4.1.5"
+    "truffle": "^4.1.13"
   },
   "dependencies": {
     "bignumber.js": "^7.2.0",
     "chalk": "^2.4.1",
     "ethereumjs-abi": "^0.6.5",
     "openzeppelin-solidity": "~1.9.0",
-    "truffle-contract": "^3.0.5",
-    "truffle-provisioner": "^0.1.0",
+    "truffle-contract": "^3.0.6",
+    "truffle-provisioner": "^0.1.1",
     "web3": "^0.18.4"
   }
 }


### PR DESCRIPTION
Fixes #162 

This PR:
- Updates truffle to use latest solc version
- Updates current version of OZ to 1.10.0
- Adapts constructor using the new syntax
- Adds reasons to all require statements except for proxy calls

Discussed offline: we are not considering this a breaking change, merging against `master`