### PR TITLE
Add method changeProxyAdmin to BaseApp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support custom Truffle build directories
 - Reason messages to require statements
 - Proxy wrapper object to allow querying proxies' admin and implementation
+- New `changeProxyAdmin` method in App contract and associated javascript model
 - Changelog file
 
 ### Changed

--- a/contracts/application/BaseApp.sol
+++ b/contracts/application/BaseApp.sol
@@ -105,4 +105,13 @@ contract BaseApp is Ownable {
   function getProxyAdmin(AdminUpgradeabilityProxy proxy) public view returns (address) {
     return proxy.admin();
   }
+
+  /**
+   * @dev Changes the admin of a proxy.
+   * @param proxy Proxy to change admin.
+   * @param newAdmin Address to transfer proxy administration to.
+   */
+  function changeProxyAdmin(AdminUpgradeabilityProxy proxy, address newAdmin) public onlyOwner {
+    proxy.changeAdmin(newAdmin);
+  }
 }

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -97,6 +97,12 @@ export default class App {
     this.version = versionName
   }
 
+  async changeProxyAdmin(proxyAddress, newAdmin) {
+    log.info(`Changing admin for proxy ${proxyAddress} to ${newAdmin}...`)
+    await this._app.changeProxyAdmin(proxyAddress, newAdmin, this.txParams)
+    log.info(` Admin for proxy ${proxyAddress} set to ${newAdmin}`)
+  }
+
   async createProxy(contractClass, contractName, initMethodName, initArgs) {
     if (!contractName) contractName = contractClass.contractName;
     const { receipt } = typeof(initArgs) === 'undefined'

--- a/test/contracts/application/PackagedApp.test.js
+++ b/test/contracts/application/PackagedApp.test.js
@@ -318,5 +318,22 @@ contract('PackagedApp', ([_, appOwner, packageOwner, directoryOwner, anotherAcco
         })
       })
     })
+
+    describe('changeAdmin', function () {
+      beforeEach(async function () {
+        await this.zeroVersionDirectory.setImplementation(contract, this.implementation_v0, { from: directoryOwner })
+        const { receipt } = await this.app.create(contract)
+        this.logs = decodeLogs(receipt.logs, UpgradeabilityProxyFactory)
+        this.proxyAddress = this.logs.find(l => l.event === 'ProxyCreated').args.proxy
+        this.proxy = await AdminUpgradeabilityProxy.at(this.proxyAddress)
+      })
+
+      it('changes admin of the proxy', async function () {
+        await this.app.changeProxyAdmin(this.proxyAddress, anotherAccount, { from: appOwner });
+        const proxy = Proxy.at(this.proxyAddress);
+        const admin = await proxy.admin();
+        admin.should.be.equal(anotherAccount);
+      });
+    })
   })
 })

--- a/test/contracts/application/UnversionedApp.test.js
+++ b/test/contracts/application/UnversionedApp.test.js
@@ -232,4 +232,20 @@ contract('UnversionedApp', ([_, appOwner, directoryOwner, anotherAccount]) => {
       })
     })
   })
+
+  describe('changeAdmin', function () {
+    beforeEach(async function () {
+      await this.directory.setImplementation(contract, this.implementation_v0, { from: directoryOwner })
+      const { receipt } = await this.app.create(contract)
+      this.logs = decodeLogs(receipt.logs, UpgradeabilityProxyFactory)
+      this.proxyAddress = this.logs.find(l => l.event === 'ProxyCreated').args.proxy
+    })
+
+    it('changes admin of the proxy', async function () {
+      await this.app.changeProxyAdmin(this.proxyAddress, anotherAccount, { from: appOwner });
+      const proxy = Proxy.at(this.proxyAddress);
+      const admin = await proxy.admin();
+      admin.should.be.equal(anotherAccount);
+    });
+  })
 })

--- a/test/src/app/App.test.js
+++ b/test/src/app/App.test.js
@@ -3,13 +3,14 @@ require('../../setup')
 
 import App from '../../../src/app/App';
 import Contracts from '../../../src/utils/Contracts'
+import Proxy from '../../../src/utils/Proxy';
 
 const AppDirectory = Contracts.getFromLocal('AppDirectory');
 const Impl = Contracts.getFromLocal('Impl');
 const ImplV1 = Contracts.getFromLocal('DummyImplementation');
 const ImplV2 = Contracts.getFromLocal('DummyImplementationV2');
 
-contract('App', function ([_, owner]) {
+contract('App', function ([_, owner, otherAdmin]) {
   const txParams = { from: owner }
   const initialVersion = '1.0';
   const contractName = 'Impl';
@@ -234,6 +235,18 @@ contract('App', function ([_, owner]) {
       });
 
       shouldConnectToStdlib();
+    });
+
+    describe('changeProxyAdmin', function () {
+      beforeEach('setting implementation', setImplementation);
+      beforeEach('create proxy', createProxy);
+
+      it('should change proxy admin', async function () {
+        await this.app.changeProxyAdmin(this.proxy.address, otherAdmin);
+        const proxyWrapper = Proxy.at(this.proxy.address);
+        const actualAdmin = await proxyWrapper.admin();
+        actualAdmin.should.be.eq(otherAdmin);
+      });
     });
   });
 


### PR DESCRIPTION
Given the app is the owner of all proxies by default, it should provide a way to transfer the ownership to a different address. This PR adds a `changeProxyAdmin` method to the contract and the js wrapper.