### PR TITLE
Use promisify for web3 sync functions

### DIFF
--- a/examples/complex/test/helpers/getBalance.js
+++ b/examples/complex/test/helpers/getBalance.js
@@ -1,8 +1,6 @@
+import { promisify } from 'util'
+
 export default async function getBalance(address) {
-  return new Promise(function(resolve, reject) {
-    web3.eth.getBalance(address, function(error, result) {
-      if(error) reject(error);
-      else resolve(+web3.fromWei(result.toNumber(), 'ether'));
-    });
-  });
+  let result = await promisify(web3.eth.getBalance.bind(web3.eth))(address);
+  return +web3.fromWei(result.toNumber(), 'ether');
 }

--- a/src/utils/Proxy.js
+++ b/src/utils/Proxy.js
@@ -1,3 +1,5 @@
+import { promisify } from 'util'
+
 export default class Proxy {
   static at(address) {
     return new Proxy(address)
@@ -18,6 +20,6 @@ export default class Proxy {
   }
 
   async getStorageAt(position) {
-    return web3.eth.getStorageAt(this.address, position)
+    return promisify(web3.eth.getStorageAt.bind(web3.eth))(this.address, position)
   }
 }


### PR DESCRIPTION
Hey guys. I'm sorry for the delay.

I've tried to find every instance of web3 synchronous calls, and make them async via node's built-in (>= v8) `promisify`. Please let me know if you'd prefer a different approach, or if there are calls I haven't converted.

Fixes #205 